### PR TITLE
Issue 59/extrapolation

### DIFF
--- a/src/client/ClientGame.cpp
+++ b/src/client/ClientGame.cpp
@@ -12,6 +12,15 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <cmath>
+
+static std::pair<float,float> lerp2(const std::pair<float,float>& a,
+                                   const std::pair<float,float>& b,
+                                   float t)
+{
+    return { a.first + (b.first - a.first) * t,
+             a.second + (b.second - a.second) * t };
+}
 
 /**
  * @brief Constructor for ClientGame. Init the window with a nice starfield
@@ -20,6 +29,7 @@
 ClientGame::ClientGame(std::string ip, int port, NetworkBuffer *netBuffer): client(ip, port, netBuffer)
 {
     _netBuffer = netBuffer;
+    _inputManager.setClientGame(this);
     data.window.create(sf::VideoMode({1920, 1080}), "RTYPE");
     data.window.clear(sf::Color::Black);
     data.window.setActive(true);
@@ -55,7 +65,7 @@ void ClientGame::Update() {
 }
 
 /**
- * @brief main loop for ClientGame. clear window, display, and retrieves events. Does not update/draw the entities if paused
+ * @brief main loop for ClientGame. clear window, display, and retrieves events.
  *
  */
 void ClientGame::Loop() {
@@ -65,8 +75,9 @@ void ClientGame::Loop() {
             return;
         data.window.clear(sf::Color::Black);
         if (!Paused) {
-            Update();
             processNetworkPackets();
+            applyNetworkInterpolation();
+            Update();
         }
         data.window.display();
         while(data.window.pollEvent(evt)) {
@@ -79,10 +90,6 @@ void ClientGame::Loop() {
 
 /**
  * @brief creates an entity based on its entity type, and assigns it an ID and a position
- *
- * @param entity_type the entity type to create. If not found, does not creates and entity
- * @param entity_id id allocated by the server for the entity
- * @param position position of the entity. Does nothing if the entity does not have the component POSITION
  */
 void ClientGame::createEntity(int entity_type, int entity_id, std::pair<float, float> position) {
     int prevSize = data.entityList.size();
@@ -109,13 +116,8 @@ void ClientGame::createEntity(int entity_type, int entity_id, std::pair<float, f
 }
 
 /**
- * @brief changes the entity position
- *
- * @param entity_type entity type
- * @param entity_id id allocated by the server for the entity
- * @param new_position new position of the entity. Does nothing if the entity does not have the component POSITION
+ * @brief changes the entity position,
  */
-
 void ClientGame::moveEntity(int entity_type, int entity_id, std::pair<float, float> new_position) {
     for (size_t i = 0; i < data.entityList.size(); i++) {
         if (!data.entityList[i]->is_wanted_entity(entity_type, entity_id))
@@ -129,9 +131,6 @@ void ClientGame::moveEntity(int entity_type, int entity_id, std::pair<float, flo
 
 /**
  * @brief deletes the specified entity
- *
- * @param entity_type entity type
- * @param entity_id id allocated by the server for the entity
  */
 void ClientGame::deleteEntity(int entity_type, int entity_id) {
     std::cout << "[DELETE] looking for type=" << entity_type
@@ -141,7 +140,6 @@ void ClientGame::deleteEntity(int entity_type, int entity_id) {
         std::cout << "  entity type=" << e->getType()
                   << " id=" << e->getId() << "\n";
     }
-
     std::erase_if(data.entityList, [&](const auto& e) {
         return e->is_wanted_entity(entity_type, entity_id);
     });
@@ -149,7 +147,6 @@ void ClientGame::deleteEntity(int entity_type, int entity_id) {
 
 /**
  * @brief checks if the game is pause. Necessary to avoid multiple threads looking at the same variable
- *
  */
 bool ClientGame::isPaused() {
     bool value;
@@ -159,21 +156,12 @@ bool ClientGame::isPaused() {
     return value;
 }
 
-/**
- * @brief modifies the game pause value. Necessary to avoid multiple threads looking at the same variable
- *
- * @param value new pause value
- */
 void ClientGame::setPaused(bool value) {
     pause_mutex.lock();
     Paused = value;
     pause_mutex.unlock();
 }
 
-/**
- * @brief checks if the game is Stopped. Necessary to avoid multiple threads looking at the same variable
- *
- */
 bool ClientGame::isStop() {
     bool value;
     pause_mutex.lock();
@@ -182,43 +170,138 @@ bool ClientGame::isStop() {
     return value;
 }
 
-/**
- * @brief modifies the game stop value. Necessary to avoid multiple threads looking at the same variable
- *
- * @param value new pause value
- */
 void ClientGame::setStop(bool value) {
     pause_mutex.lock();
     Stopping = value;
     pause_mutex.unlock();
 }
 
+void ClientGame::pushSnapshot(uint8_t type, uint16_t id, uint32_t tick, float x, float y)
+{
+    uint32_t key = makeKey(type, id);
+    _latestServerTick = std::max(_latestServerTick, tick);
+
+    auto &q = _netBuffers[key].snaps;
+    if (!q.empty() && q.back().tick == tick) {
+        q.back().pos = {x, y};
+    } else {
+        q.push_back({tick, {x, y}});
+    }
+
+    while (q.size() > MAX_SNAPSHOTS)
+        q.pop_front();
+}
+
+void ClientGame::applyNetworkInterpolation()
+{
+    if (_latestServerTick <= INTERP_DELAY_TICKS)
+        return;
+
+    uint32_t renderTick = _latestServerTick - INTERP_DELAY_TICKS;
+
+    for (auto &[key, buf] : _netBuffers) {
+        auto &snaps = buf.snaps;
+        if (snaps.size() < 2)
+            continue;
+        int type = int((key >> 16) & 0xFF);
+        int id   = int(key & 0xFFFF);
+        IMediatorEntity *ent = nullptr;
+        for (auto &ptr : data.entityList) {
+            if (ptr->is_wanted_entity(type, id)) {
+                ent = ptr.get();
+                break;
+            }
+        }
+        if (!ent)
+            continue;
+        Snapshot *a = nullptr;
+        Snapshot *b = nullptr;
+        for (size_t i = 0; i + 1 < snaps.size(); ++i) {
+            if (snaps[i].tick <= renderTick && renderTick <= snaps[i + 1].tick) {
+                a = &snaps[i];
+                b = &snaps[i + 1];
+                break;
+            }
+        }
+        std::pair<float,float> finalPos = snaps.back().pos;
+        if (a && b && b->tick != a->tick) {
+            float t = float(renderTick - a->tick) / float(b->tick - a->tick);
+            finalPos = lerp2(a->pos, b->pos, t);
+        } else {
+            const auto &s0 = snaps[snaps.size() - 2];
+            const auto &s1 = snaps[snaps.size() - 1];
+
+            uint32_t dtTicks = 0;
+            if (renderTick > s1.tick)
+                dtTicks = std::min<uint32_t>(renderTick - s1.tick, MAX_EXTRAP_TICKS);
+
+            float denom = float(std::max<uint32_t>(1, s1.tick - s0.tick));
+            float vx = (s1.pos.first  - s0.pos.first)  / denom;
+            float vy = (s1.pos.second - s0.pos.second) / denom;
+
+            finalPos = { s1.pos.first  + vx * dtTicks,
+                         s1.pos.second + vy * dtTicks };
+        }
+        Position *pos = dynamic_cast<Position*>(ent->FindComponent(ComponentType::POSITION));
+        if (pos) {
+            pos->SetPosition(finalPos);
+        }
+        while (snaps.size() >= 2 && snaps[1].tick < renderTick) {
+            snaps.pop_front();
+        }
+    }
+}
+
 void ClientGame::processNetworkPackets()
 {
     auto packets = _netBuffer->popAllPackets();
-//    if (packets.size() != 0)
-//        std::cout << "Packet Size: " << packets.size() << ", " << (int)packets[0].actionType << std::endl;
+
     for (size_t i = 0; i < packets.size(); i++) {
-        switch ((int)packets[i].actionType)
+        const auto &p = packets[i];
+        switch ((int)p.actionType)
         {
-        case 0:
-            //std::cout << "ENTITY CREATED\n";
-            createEntity((int)packets[i].entityType, (int)packets[i].entityId, {(int)packets[i].posX, (int)packets[i].posY});
+        case 0: {
+            createEntity((int)p.entityType, (int)p.entityId, {(float)p.posX, (float)p.posY});
+            pushSnapshot(p.entityType, p.entityId, p.serverTick, (float)p.posX, (float)p.posY);
             break;
-        case 1:
-            //std::cout << "ENTITY MOVED\n";
-            moveEntity((int)packets[i].entityType, (int)packets[i].entityId, {(int)packets[i].posX, (int)packets[i].posY});
+        }
+        case 1: {
+            pushSnapshot(p.entityType, p.entityId, p.serverTick, (float)p.posX, (float)p.posY);
             break;
-        case 2:
-            //std::cout << "ENTITY DELETED\n";
-            std::cout << "Message actionType: " << (int)packets[i].actionType << "\n";
-            std::cout << "Message affected entity: " << (int)packets[i].entityId << " type: " << (int)packets[i].entityType << "\n";
-            deleteEntity((int)packets[i].entityType, (int)packets[i].entityId);
+        }
+        case 2: {
+            uint32_t key = makeKey(p.entityType, p.entityId);
+            _netBuffers.erase(key);
+
+            deleteEntity((int)p.entityType, (int)p.entityId);
             break;
+        }
         case 14:
             setStop(true);
+            break;
         default:
             break;
         }
+    }
+}
+
+void ClientGame::predictLocalMove(float dx, float dy)
+{
+    if (_localPlayerId < 0)
+        return;
+
+    for (auto &e : data.entityList) {
+        if (!e->is_wanted_entity(ENTITY_PLAYER, _localPlayerId))
+            continue;
+        Position *p = dynamic_cast<Position*>(e->FindComponent(ComponentType::POSITION));
+        if (!p)
+            return;
+        auto pos = p->GetPosition();
+        // ptet ajuster ca
+        float speed = 300.f;
+        pos.first  += dx * speed * data.runtime;
+        pos.second += dy * speed * data.runtime;
+        p->SetPosition(pos);
+        return;
     }
 }

--- a/src/client/ClientGame.hpp
+++ b/src/client/ClientGame.hpp
@@ -7,6 +7,11 @@
 #include <memory>
 #include <mutex>
 #include <vector>
+#include <unordered_map>
+#include <deque>
+#include <utility>
+#include <algorithm>
+#include <cstdint>
 
 #include "../ecs/System/ISystem.hpp"
 #include "../ecs/relevant_data.hpp"
@@ -25,22 +30,50 @@ class ClientGame {
         bool Stopping = false;
         bool Paused = false;
         std::mutex pause_mutex;
+        int _localPlayerId = -1;
 
         NetworkBuffer *_netBuffer = nullptr;
         Client client;
 
+        struct Snapshot {
+            uint32_t tick;
+            std::pair<float, float> pos;
+        };
+
+        struct NetInterpBuffer {
+            std::deque<Snapshot> snaps;
+        };
+
+        std::unordered_map<uint32_t, NetInterpBuffer> _netBuffers;
+        uint32_t _latestServerTick = 0;
+
+        static constexpr uint32_t INTERP_DELAY_TICKS = 6;
+        static constexpr uint32_t MAX_EXTRAP_TICKS   = 6;
+        static constexpr size_t   MAX_SNAPSHOTS      = 32;
+
+        static uint32_t makeKey(uint8_t type, uint16_t id) {
+            return (uint32_t(type) << 16) | uint32_t(id);
+        }
+
+        void pushSnapshot(uint8_t type, uint16_t id, uint32_t tick, float x, float y);
+        void applyNetworkInterpolation();
+
     public:
         ClientGame(std::string ip, int port, NetworkBuffer *netBuffer);
         ~ClientGame() = default;
+
         void createEntity(int, int, std::pair<float, float>);
         void moveEntity(int, int, std::pair<float, float>);
         void deleteEntity(int, int);
+
         bool isPaused();
         void setPaused(bool);
         bool isStop();
         void setStop(bool);
+
         void Update();
         void Loop();
-
         void processNetworkPackets();
+
+        void predictLocalMove(float, float);
 };

--- a/src/client/Packet.hpp
+++ b/src/client/Packet.hpp
@@ -16,6 +16,8 @@ struct NetworkPacket {
     uint8_t entityType;
     uint16_t entityId;
 
+    uint32_t serverTick;
+
     uint16_t posX;
     uint16_t posY;
 };

--- a/src/client/PacketCodec.cpp
+++ b/src/client/PacketCodec.cpp
@@ -54,10 +54,9 @@ Packet encodeClientPacket(
  * @param size Number of bytes received.
  * @return ServerPacket Decoded packet structure.
  */
-NetworkPacket decodeNetworkPacket(std::vector<uint8_t>b, size_t size) {
-    NetworkPacket p {};
+NetworkPacket decodeNetworkPacket(std::vector<uint8_t> b, size_t size) {
+    NetworkPacket p{};
 
-    //std::cout << "Decoding..." << std::endl;
     p.packetId = (static_cast<uint32_t>(b.at(0)) << 8u) | b[1];
     p.payloadSize = (static_cast<uint32_t>(b.at(2)) >> 4u) & 0x0Fu;
     p.actionType  =  b.at(2) & 0x0Fu;
@@ -67,9 +66,21 @@ NetworkPacket decodeNetworkPacket(std::vector<uint8_t>b, size_t size) {
 
     if (p.payloadSize >= 1) p.entityType = b[3];
     if (p.payloadSize >= 3) p.entityId = (static_cast<uint32_t>(b.at(4)) << 8u) | b[5];
-    if (p.payloadSize >= 6) {
-        uint32_t pos = (static_cast<uint32_t>(b.at(6)) << 16u) |
-        (static_cast<uint32_t>(b.at(7)) << 8u) | b[8];
+
+    if (p.payloadSize >= 7) {
+        p.serverTick =
+            (static_cast<uint32_t>(b.at(6)) << 24u) |
+            (static_cast<uint32_t>(b.at(7)) << 16u) |
+            (static_cast<uint32_t>(b.at(8)) <<  8u) |
+            (static_cast<uint32_t>(b.at(9)));
+    }
+
+    if (p.payloadSize >= 10) {
+        uint32_t pos =
+            (static_cast<uint32_t>(b.at(10)) << 16u) |
+            (static_cast<uint32_t>(b.at(11)) <<  8u) |
+            (static_cast<uint32_t>(b.at(12)));
+
         p.posX = (pos >> 12u) & 0xFFFu;
         p.posY = pos & 0xFFFu;
     }

--- a/src/client/graphical/InputManager.cpp
+++ b/src/client/graphical/InputManager.cpp
@@ -1,6 +1,7 @@
 #include "InputManager.hpp"
 #include <cstddef>
 #include <iostream>
+#include "../ClientGame.hpp"
 
 /**
  * @brief Construct a new Input Manager:: Input Manager object
@@ -15,6 +16,7 @@ InputManager::InputManager() : textBuffer("")
     _keyBindings.at(Action::Right) = sf::Keyboard::D;
     _keyBindings.at(Action::Fire)  = sf::Keyboard::Space;
 }
+
 /**
  * @brief set the client of the input manager
  *
@@ -23,6 +25,11 @@ InputManager::InputManager() : textBuffer("")
 void InputManager::setClient(Client* client)
 {
     _client = client;
+}
+
+void InputManager::setClientGame(ClientGame* game)
+{
+    _clientGame = game;
 }
 
 /**
@@ -69,15 +76,26 @@ bool InputManager::isActionPressed(Action action) const
  */
 void InputManager::processEvent(const sf::Event& event)
 {
+    if (!_client)
+        return;
+
     if (event.type == sf::Event::KeyPressed) {
-        if (event.key.code == getKey(Action::Up))
+        if (event.key.code == getKey(Action::Up)) {
             _client->sendInput(true, static_cast<uint8_t>(Action::Up));
-        if (event.key.code == getKey(Action::Down))
+            if (_clientGame) _clientGame->predictLocalMove(0.f, -1.f);
+        }
+        if (event.key.code == getKey(Action::Down)) {
             _client->sendInput(true, static_cast<uint8_t>(Action::Down));
-        if (event.key.code == getKey(Action::Left))
+            if (_clientGame) _clientGame->predictLocalMove(0.f, 1.f);
+        }
+        if (event.key.code == getKey(Action::Left)) {
             _client->sendInput(true, static_cast<uint8_t>(Action::Left));
-        if (event.key.code == getKey(Action::Right))
+            if (_clientGame) _clientGame->predictLocalMove(-1.f, 0.f);
+        }
+        if (event.key.code == getKey(Action::Right)) {
             _client->sendInput(true, static_cast<uint8_t>(Action::Right));
+            if (_clientGame) _clientGame->predictLocalMove(1.f, 0.f);
+        }
         if (event.key.code == getKey(Action::Fire))
             _client->sendInput(true, static_cast<uint8_t>(Action::Fire));
     }

--- a/src/client/graphical/InputManager.hpp
+++ b/src/client/graphical/InputManager.hpp
@@ -7,6 +7,8 @@
 #include <vector>
 #include "../client.hpp"
 
+class ClientGame;
+
 /**
  * @brief action type enum
  *
@@ -32,6 +34,7 @@ private:
 
     std::string textBuffer;
     Client* _client = nullptr;
+    ClientGame* _clientGame = nullptr;
 
     Action keyToAction(sf::Keyboard::Key key) const;
 
@@ -40,6 +43,7 @@ public:
     ~InputManager() = default;
 
     void setClient(Client* client);
+    void setClientGame(ClientGame* game);
 
     void bindKey(Action action, sf::Keyboard::Key key);
     sf::Keyboard::Key getKey(Action action) const;

--- a/src/ecs/System/CollisionSystem.cpp
+++ b/src/ecs/System/CollisionSystem.cpp
@@ -87,7 +87,7 @@ void CollisionSystem::executeEntity(IMediatorEntity &entity, relevant_data_t &da
             playerHp->SubHp(entityHitbox->GetDamage());
             if (playerHp->GetHp() <= 0) {
                 std::cout << "Entity " << entityList[i]->getType() << " is dead !" << std::endl;
-                entity.Alive(false);
+                entityList[i]->Alive(false);
             }
         }
         entityHp = dynamic_cast<Hp*>(entityList[i]->FindComponent(ComponentType::HP));

--- a/src/server/ServerGame.cpp
+++ b/src/server/ServerGame.cpp
@@ -56,7 +56,7 @@ void ServerGame::Update() {
         if (!data.entityList[j]->is_Alive()) {
             std::vector<uint8_t> pkt = encoder.encodeDelete(networkServer.currentID, data.entityList[j]->getType(), data.entityList[j]->getId());
             networkSendBuffer->pushPacket(pkt);
-            continuousBuffer->pushPacket(pkt);
+            continuousBuffer->deleteEntity(data.entityList[j]->getType(), data.entityList[j]->getId());
             data.entityList.erase(data.entityList.begin() + j);
             j--;
             EListSize--;
@@ -69,7 +69,7 @@ void ServerGame::Update() {
             std::vector<uint8_t> pkt = encoder.encodeCreate(networkServer.currentID,data.entityList[j]->getType(),
                 data.entityList[j]->getId(), _serverTick, playerPos->GetPosition().first, playerPos->GetPosition().second);
             networkSendBuffer->pushPacket(pkt);
-            continuousBuffer->addEntity(type, id, pkt);
+            continuousBuffer->addEntity(data.entityList[j]->getType(), data.entityList[j]->getId(), pkt);
             continue;
         }
         if (data.entityList[j]->hasChanged()) {
@@ -78,6 +78,7 @@ void ServerGame::Update() {
                 continue;
             std::vector<uint8_t> pkt = encoder.encodeMove(networkServer.currentID, data.entityList[j]->getType(),
                 data.entityList[j]->getId(), _serverTick , playerPos->GetPosition().first, playerPos->GetPosition().second);
+            continuousBuffer->moveEntity(data.entityList[j]->getType(), data.entityList[j]->getId(), pkt);
             networkSendBuffer->pushPacket(pkt);
             continue;
         }

--- a/src/server/ServerGame.cpp
+++ b/src/server/ServerGame.cpp
@@ -31,6 +31,8 @@ ServerGame::ServerGame(int port, NetworkServerBuffer *newRBuffer, NetworkClientB
     networkServer(port,
     newRBuffer, newSBuffer, newCBuffer)
 {
+    data.bullet_count = 0;
+    data.enemy_count = 0;
     clock.restart();
     Prevtime = clock.getElapsedTime();
     systemList.push_back(std::make_unique<ShootSystem>());
@@ -48,6 +50,7 @@ void ServerGame::Update() {
 
     size_t SListSize = systemList.size();
     size_t EListSize = data.entityList.size();
+    _serverTick++;
     for (size_t j = 0; j < EListSize; j++) {
         for (size_t i = 0; i < SListSize; i++)
             systemList[i]->checkEntity(*data.entityList[j].get(), data);
@@ -56,7 +59,7 @@ void ServerGame::Update() {
             if (playerPos == nullptr)
                 continue;
             std::vector<uint8_t> pkt = encoder.encodeCreate(networkServer.currentID,data.entityList[j]->getType(),
-                data.entityList[j]->getId(), playerPos->GetPosition().first, playerPos->GetPosition().second);
+                data.entityList[j]->getId(), _serverTick, playerPos->GetPosition().first, playerPos->GetPosition().second);
             networkSendBuffer->pushPacket(pkt);
             continuousBuffer->pushPacket(pkt);
             continue;
@@ -75,7 +78,7 @@ void ServerGame::Update() {
             if (playerPos == nullptr)
                 continue;
             std::vector<uint8_t> pkt = encoder.encodeMove(networkServer.currentID, data.entityList[j]->getType(),
-                data.entityList[j]->getId(), playerPos->GetPosition().first, playerPos->GetPosition().second);
+                data.entityList[j]->getId(), _serverTick , playerPos->GetPosition().first, playerPos->GetPosition().second);
             networkSendBuffer->pushPacket(pkt);
             continue;
         }

--- a/src/server/ServerGame.cpp
+++ b/src/server/ServerGame.cpp
@@ -54,6 +54,15 @@ void ServerGame::Update() {
     for (size_t j = 0; j < EListSize; j++) {
         for (size_t i = 0; i < SListSize; i++)
             systemList[i]->checkEntity(*data.entityList[j].get(), data);
+        if (!data.entityList[j]->is_Alive()) {
+            std::vector<uint8_t> pkt = encoder.encodeDelete(networkServer.currentID, data.entityList[j]->getType(), data.entityList[j]->getId());
+            networkSendBuffer->pushPacket(pkt);
+            continuousBuffer->pushPacket(pkt);
+            data.entityList.erase(data.entityList.begin() + j);
+            j--;
+            EListSize--;
+            continue;
+        }
         if (data.entityList[j]->justCreated()) {
             Position *playerPos = dynamic_cast<Position*>(data.entityList[j]->FindComponent(ComponentType::POSITION));
             if (playerPos == nullptr)
@@ -63,15 +72,6 @@ void ServerGame::Update() {
             networkSendBuffer->pushPacket(pkt);
             continuousBuffer->pushPacket(pkt);
             continue;
-        }
-        if (!data.entityList[j]->is_Alive()) {
-            std::vector<uint8_t> pkt = encoder.encodeDelete(networkServer.currentID, data.entityList[j]->getType(), data.entityList[j]->getId());
-            networkSendBuffer->pushPacket(pkt);
-            continuousBuffer->pushPacket(pkt);
-            data.entityList.erase(data.entityList.begin() + j);
-            j--;
-            EListSize--;
-           continue;
         }
         if (data.entityList[j]->hasChanged()) {
             Position *playerPos = dynamic_cast<Position*>(data.entityList[j]->FindComponent(ComponentType::POSITION));

--- a/src/server/ServerGame.hpp
+++ b/src/server/ServerGame.hpp
@@ -21,6 +21,7 @@ class ServerGame {
         sf::Time Prevtime;
         sf::Clock clock;
         bool Running = false;
+        uint32_t _serverTick = 0;
 
         NetworkServerBuffer *networkReceiveBuffer;
         NetworkClientBuffer *networkSendBuffer;

--- a/src/server/encoder.hpp
+++ b/src/server/encoder.hpp
@@ -63,6 +63,40 @@ private:
             return out;
         }
 
+    static std::vector<uint8_t> encodeWithTick(
+        uint16_t packetID, uint8_t actionType,
+        uint8_t entityType, uint16_t entityID,
+        uint32_t serverTick,
+        uint16_t posX, uint16_t posY)
+    {
+        constexpr uint8_t payloadSize = 10;
+        std::vector<uint8_t> out(3 + payloadSize);
+
+        out[0] = static_cast<uint8_t>((packetID >> 8u) & 0xFFu);
+        out[1] = static_cast<uint8_t>( packetID        & 0xFFu);
+        out[2] = static_cast<uint8_t>(((payloadSize & 0x0Fu) << 4u) |
+                                    ( actionType  & 0x0Fu));
+
+        out[3] = entityType;
+        out[4] = static_cast<uint8_t>((entityID >> 8u) & 0xFFu);
+        out[5] = static_cast<uint8_t>( entityID        & 0xFFu);
+
+        out[6] = static_cast<uint8_t>((serverTick >> 24u) & 0xFFu);
+        out[7] = static_cast<uint8_t>((serverTick >> 16u) & 0xFFu);
+        out[8] = static_cast<uint8_t>((serverTick >>  8u) & 0xFFu);
+        out[9] = static_cast<uint8_t>( serverTick         & 0xFFu);
+
+        posX &= 0x0FFFu;
+        posY &= 0x0FFFu;
+        uint32_t pos24 = (uint32_t(posX) << 12u) | uint32_t(posY);
+
+        out[10] = static_cast<uint8_t>((pos24 >> 16u) & 0xFFu);
+        out[11] = static_cast<uint8_t>((pos24 >>  8u) & 0xFFu);
+        out[12] = static_cast<uint8_t>( pos24         & 0xFFu);
+
+        return out;
+    }
+
 public:
         /**
          * @brief helper functions that creates an entity
@@ -77,15 +111,19 @@ public:
     static std::vector<uint8_t> encodeCreate(
         uint16_t packetID,
         uint8_t entityType, uint16_t entityID,
-        uint16_t posX, uint16_t posY) {
-            return encode(packetID,
-                6,
-                ENTITY_CREATED,
-                entityType,
-                entityID,
-                posX,
-                posY);
-        }
+        uint16_t posX, uint16_t posY)
+    {
+        return encodeWithTick(packetID, ENTITY_CREATED, entityType, entityID, 0, posX, posY);
+    }
+
+    static std::vector<uint8_t> encodeCreate(
+        uint16_t packetID,
+        uint8_t entityType, uint16_t entityID,
+        uint32_t serverTick,
+        uint16_t posX, uint16_t posY)
+    {
+        return encodeWithTick(packetID, ENTITY_CREATED, entityType, entityID, serverTick, posX, posY);
+    }
 
     /**
      * @brief helper functions to signal that an entity has moved
@@ -100,15 +138,19 @@ public:
     static std::vector<uint8_t> encodeMove(
         uint16_t packetID,
         uint8_t entityType, uint16_t entityID,
-        uint16_t posX, uint16_t posY) {
-            return encode(packetID,
-                6,
-                ENTITY_MOVED,
-                entityType,
-                entityID,
-                posX,
-                posY);
-        }
+        uint16_t posX, uint16_t posY)
+    {
+        return encodeWithTick(packetID, ENTITY_MOVED, entityType, entityID, 0, posX, posY);
+    }
+
+    static std::vector<uint8_t> encodeMove(
+        uint16_t packetID,
+        uint8_t entityType, uint16_t entityID,
+        uint32_t serverTick,
+        uint16_t posX, uint16_t posY)
+    {
+        return encodeWithTick(packetID, ENTITY_MOVED, entityType, entityID, serverTick, posX, posY);
+    }
 
     /**
      * @brief helper functions to signal that an entity has been deleted


### PR DESCRIPTION
# Feature Addition PR Template Name - Network interpolation/extrapolation

## Issues closed
Closes #59 

## Changes
- Added `serverTick` to server MOVE and CREATE packets
- Implemented snapshot buffering per entity on the client
- Added interpolation
- Added extrapolation when packets are delayed or missing
- Implemented client-side prediction for the local player to remove input lag
